### PR TITLE
Pass all page results, instead of just the PIDs...

### DIFF
--- a/includes/manage_book.inc
+++ b/includes/manage_book.inc
@@ -175,25 +175,36 @@ function islandora_book_manage_book_pdf_form_submit(array $form, array &$form_st
 function islandora_book_manage_book_ocr_form(array $form, array &$form_state, FedoraObject $object) {
   module_load_include('inc', 'islandora_ocr', 'includes/utilities');
   $form_state['object'] = $object;
-  $can_derive = islandora_ocr_can_derive_ocr();
-  $languages = islandora_ocr_get_enabled_tesseract_languages();
-  return array(
-    'description' => array(
-      '#type' => 'item',
-      '#description' => t('You must have the <b>Tesseract</b> installed to perform OCR, and <b>Gimp</b> to preprocess OCR.<br/> This will update the OCR and HOCR datastreams for each Page object.'),
-    ),
-    'language' => array(
-      '#title' => t('Language'),
-      '#type' => 'select',
-      '#description' => t('Please select the language that the page is written in.'),
-      '#options' => $languages,
-    ),
-    'submit' => array(
-      '#disabled' => !$can_derive,
-      '#type' => 'submit',
-      '#value' => t('Create OCR'),
-    ),
-  );
+  if (module_exists('islandora_ocr')) {
+    $can_derive = islandora_ocr_can_derive_ocr();
+    $languages = islandora_ocr_get_enabled_tesseract_languages();
+    return array(
+      'description' => array(
+        '#type' => 'item',
+        '#description' => t('You must have the <b>Tesseract</b> installed to perform OCR, and <b>Gimp</b> to preprocess OCR.<br/> This will update the OCR and HOCR datastreams for each Page object.'),
+      ),
+      'language' => array(
+        '#title' => t('Language'),
+        '#type' => 'select',
+        '#description' => t('Please select the language that the page is written in.'),
+        '#options' => $languages,
+      ),
+      'submit' => array(
+        '#disabled' => !$can_derive,
+        '#type' => 'submit',
+        '#value' => t('Create OCR'),
+      ),
+    );
+  }
+  else {
+    return array(
+      'sorry' => array(
+        '#type' => 'item',
+        '#markup' => t('The OCR module must be installed and enabled in ' .
+          'order for this form to be used.'),
+      ),
+    );
+  }
 }
 
 /**

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -13,7 +13,7 @@ function islandora_book_preprocess_islandora_book_book(array &$variables) {
   $object = $variables['object'];
   $params = array(
     'object' => $object,
-    'pages' => array_keys(islandora_paged_content_get_pages($object)),
+    'pages' => islandora_paged_content_get_pages($object),
     'page_progression' => islandora_paged_content_get_page_progression($object),
   );
   module_load_include('inc', 'islandora', 'includes/solution_packs');


### PR DESCRIPTION
Also, wrap the OCR stuff so it stops breaking with an error if you don't have islandora_ocr installed.

Related to both:
https://github.com/Islandora/islandora_internet_archive_bookreader/pull/16 and
https://github.com/Islandora/islandora_paged_content/pull/7
